### PR TITLE
Fixes a media-query calculation bug when using ems.

### DIFF
--- a/scss/mixins/_responsive.scss
+++ b/scss/mixins/_responsive.scss
@@ -9,6 +9,19 @@
    ========================================================================== */
 $fix-mqs: false !default; //assign false if no value set already
 
+/**
+ * $mq-base var:
+ * This is needed because browsers do not calculate em-based
+ * media queries correctly. It is set to 16 because we think
+ * the majority of users will have their browser set to 100%
+ * zoom level.
+ *
+ * See below for an explanation:
+ * http://www.filamentgroup.com/lab/how-we-learned-to-leave-body-font-size-alone.html
+ *
+ */
+$mq-base: 16;
+
 /*
    Min-width media query:
    * Equivalent to: @media screen and (min-width: 20em) { ... }
@@ -16,7 +29,7 @@ $fix-mqs: false !default; //assign false if no value set already
    * Argument is a pixel value WITHOUT a unit of measurement
    ========================================================================== */
 @mixin respond-min($width) {
-	$width-em: em(strip-units($width));
+	$width-em: em(strip-units($width), $mq-base);
 
 	// If we're outputting for a fixed media query set...
 	@if $fix-mqs {
@@ -41,7 +54,7 @@ $fix-mqs: false !default; //assign false if no value set already
    * Argument is a pixel value WITHOUT a unit of measurement
    ========================================================================== */
 @mixin respond-max($width) {
-	$width-em: em(strip-units($width));
+	$width-em: em(strip-units($width), $mq-base);
 
 	// If we're outputting for a fixed media query set...
 	@if $fix-mqs {
@@ -68,8 +81,8 @@ $fix-mqs: false !default; //assign false if no value set already
    * Arguments are pixel values WITHOUT a unit of measurement
    ========================================================================== */
 @mixin respond-min-max($min-width, $max-width) {
-	$min-width-em: em(strip-units($min-width));
-	$max-width-em: em(strip-units($max-width));
+	$min-width-em: em(strip-units($min-width), $mq-base);
+	$max-width-em: em(strip-units($max-width), $mq-base);
 
 	// If we're outputting for a fixed media query set...
 	@if $fix-mqs {


### PR DESCRIPTION
A bug, found by @nicbell shows that `em`-based media queries are not set properly by browsers. After many attempts to fix this another way, our workaround is to use a magic number (I know, I know) set to `16`. `16` is the common value used by the majority of browsers for their default font-size, so setting it here makes our media-queries work exactly as expected. More information on this bug (or is it a feature..?) can be found at http://www.filamentgroup.com/lab/how-we-learned-to-leave-body-font-size-alone.html 

We may need to adjust some other parts of our framework soon but for now, media-queries are triggered when they are supposed to be. 